### PR TITLE
Fix: Whitelist production code

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
 
     <filter>
         <whitelist>
-            <directory>./tests/</directory>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
This PR

* [x] whitelists production code instead of test code for generating coverage