### PR TITLE
Fix: Paths to meta data and cache directories

### DIFF
--- a/src/Infrastructure/Application/Notification/DoctrineEventStore.php
+++ b/src/Infrastructure/Application/Notification/DoctrineEventStore.php
@@ -43,8 +43,8 @@ class DoctrineEventStore extends EntityRepository implements EventStore
         if (null === $this->serializer) {
             $this->serializer =
                 SerializerBuilder::create()
-                    ->addMetadataDir(__DIR__ . '/../../Infrastructure/Application/Serialization/JMS/Config')
-                    ->setCacheDir(__DIR__ . '/../../../var/cache/jms-serializer')
+                    ->addMetadataDir(__DIR__ . '/../../../Infrastructure/Application/Serialization/JMS/Config')
+                    ->setCacheDir(__DIR__ . '/../../../../var/cache/jms-serializer')
                 ->build()
             ;
         }


### PR DESCRIPTION
This PR

* [x] fixes paths to meta data and cache directories to be used by `JMS\Serializer\Serializer`