### PR TITLE
Fix: Use dedicated sections in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ php:
     - 5.6
     - hhvm
 
-before_script:
+before_install:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi;'
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = amqp.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
     - curl -s http://getcomposer.org/installer | php
+
+install:
     - php composer.phar install
 
 script: bin/phpunit


### PR DESCRIPTION
This PR

* [x] moves steps from `before_script` to `before_install` and `install` sections

:information_desk_person: For reference, see [Customizing the Build: The-Build-Lifecycle](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle).