### PR TITLE
Fix: Simplify enabling of ext/amqp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ php:
     - hhvm
 
 before_script:
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi;'
-    - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = amqp.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+    - echo "extension = amqp.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - curl -s http://getcomposer.org/installer | php
     - php composer.phar install
 


### PR DESCRIPTION
This PR

* [x] simplifies enabling of `ext/amqp` on Travis