### PR TITLE
ugrade jms/serializer to 3.9.0 so that it does not lock version in 1.X which is not compatible with php7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "jms/serializer": "~1.1",
+        "jms/serializer": "3.9.0",
         "react/event-loop": "^0.4.1"
     },
     "require-dev": {


### PR DESCRIPTION
See: https://github.com/schmittjoh/serializer/issues/1111